### PR TITLE
Update var function to strip identifiers and member expressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,12 @@ export default function ({ types: t }) {
             BinaryExpression(path) {
                 proceed(t, this.opts.var, path, removeVar);
             },
+            MemberExpression(path) {
+                proceed(t, this.opts.var, path, removeVar);
+            },
+            Identifier(path) {
+                proceed(t, this.opts.var, path, removeVar);
+            },
             // Debugger
             DebuggerStatement(path) {
                 const opts = this.opts.debugger;

--- a/src/modules/_test/data/var/.babelrc
+++ b/src/modules/_test/data/var/.babelrc
@@ -1,7 +1,7 @@
 {
     "plugins": [
         ["../../../../index.js", {
-            "var": ["stripA", "stripB", "stripC", "stripD", "stripE", "stripF", "stripG", "stripH", "stripI"]
+            "var": ["stripA", "stripB", "stripC", "stripD", "stripE", "stripF", "stripG", "stripH", "stripI", "global.stripProp", "stripIdentifier"]
         }]
     ]
 }

--- a/src/modules/_test/data/var/mock.js
+++ b/src/modules/_test/data/var/mock.js
@@ -42,3 +42,8 @@ if (stripFPattern === 'foo' && keepFPattern === 'foo') {}
 
 keepA = stripA;
 keepB = stripB && keepB;
+
+if (global.stripProp === 'foo') {}
+if (global.stripProp) {}
+if (global['stripProp']) {}
+if (stripIdentifier) {}

--- a/src/modules/_test/var.spec.js
+++ b/src/modules/_test/var.spec.js
@@ -51,6 +51,9 @@ describe('remove-code.vars', () => {
         expect(actual).to.not.contain('if (stripFPattern');
         expect(actual).to.not.contain('keepA = stripA;');
         expect(actual).to.not.contain('keepB = stripB;');
+        expect(actual).to.not.contain('stripIdentifier');
+        expect(actual).to.not.contain('global.stripProp');
+        expect(actual).to.not.contain('global[\'stripProp\']');
     });
 
     it('should maintain other vars', () => {

--- a/src/modules/var.js
+++ b/src/modules/var.js
@@ -60,6 +60,22 @@ const remove = (t, opts = [], path) => {
         if (parent && parent.type === 'ConditionalExpression') {
             toRemove = parent;
         }
+    } else if (path.type === 'Identifier') {
+        const id = getObjItem(path).join('.');
+        const isIt = matches(opts, id);
+        if (!isIt) {
+            return;
+        }
+
+        toRemove = path;
+    } else if (path.type === 'MemberExpression') {
+        const id = getObjItem(path).join('.');
+        const isIt = matches(opts, id);
+        if (!isIt) {
+            return;
+        }
+
+        toRemove = path;
     } else if (path.type === 'BinaryExpression') {
         const isIt = isEitherSide(opts, path);
         if (!isIt.isLeft && !isIt.isRight) { return; }

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,7 +37,11 @@ const getObjItem = (path) => {
     if (!path) { return arr; }
 
     // For the identifier likes...
-    arr = (path.type === 'Identifier') ? [path.name || path.node.name] : arr;
+    if (path.type === 'Identifier') {
+        arr = [path.name || path.node.name];
+    } else if (path.type === 'StringLiteral') {
+        arr = [path.value];
+    }
 
     // Lets check under other possible keys
     toCheck = path.object || path.node && path.node.object;


### PR DESCRIPTION
Identifier support will strip this:
```js
if (stripA) {}
```
Member expression support will strip these:
```js
if (strip.prop) {}

if (strip['prop']) {}
```